### PR TITLE
ci: deploy dapp as static website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,28 +1,24 @@
 ---
+# Builds the static site via webpack in a container image,
+# then copies that directory to localhost and pushes to Firebase, at:
+# https://app.testnet.penumbra.zone
 name: Deploy static site
 on:
+  # Support ad-hoc runs via dispatch, so we can deploy from
+  # unmerged feature branches if necessary.
   workflow_dispatch:
   push:
     branches:
       - main
-  # on PRs while debugging
-  pull_request:
+  # Uncomment to run on PRs; useful while debugging.
+  # pull_request:
 jobs:
   build:
     name: Render and deploy protocol and API docs
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v2
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Load Rust caching
-        uses: Swatinem/rust-cache@v1
 
       - name: Build static site
         run: ./build-static-site

--- a/build-static-site
+++ b/build-static-site
@@ -2,13 +2,16 @@
 # Script to build a static site for the Penumbra webapp,
 # designed for use with the Penumbra web extension. Requires docker.
 
-set -euo pipefail
+set -euxo pipefail
 
 >&2 echo "Removing local docroot dir... "
 rm -rf docroot/
-docker build -t penumbra_dapp .
-cid=$(podman create penumbra_dapp)
-docker cp $cid:/usr/src/app/build docroot
+# we tag with a fully-qualified name, even though we don't intend to push
+docker build -t ghcr.io/penumbra-zone/penumbra_dapp .
+# retag for local use
+docker tag ghcr.io/penumbra-zone/penumbra_dapp:latest penumbra_dapp
+cid="$(docker create penumbra_dapp)"
+docker cp "${cid}:/usr/src/app/build" docroot
 
 >&2 echo "Build complete! Website can be found in: docroot/"
 tree docroot

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,10 @@
+{
+  "hosting": {
+    "public": "docroot",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}


### PR DESCRIPTION
This PR wires up a CI workflow to deploy the code in this repository to  https://app.testnet.penumbra.zone, on pushes/merges to `main` branch. 

Once the site is live, it'll be available at https://app.testnet.penumbra.zone ; until then, leaving this PR as a draft.

Refs https://github.com/penumbra-zone/penumbra/issues/2216. 


