### PR TITLE
converts all testnet URLs HTTP -> HTTPS

### DIFF
--- a/src/components/AllValidators/index.tsx
+++ b/src/components/AllValidators/index.tsx
@@ -100,7 +100,7 @@ export const AllValidators: React.FC<AllValidatorsProps> = ({
 	// const getValidatorsCount = async () => {
 	// 	try {
 	// 		const response = await axios.get(
-	// 			'http://testnet.penumbra.zone:26657/validators'
+	// 			'https://rpc.testnet.penumbra.zone/validators'
 	// 		)
 
 	// 		// const data = await response.json()

--- a/src/containers/Validators/index.tsx
+++ b/src/containers/Validators/index.tsx
@@ -16,7 +16,7 @@ export const Validators = () => {
 
 	const getValidators = async () => {
 		const transport = createGrpcWebTransport({
-			baseUrl: 'https://testnet1.penumbra.zone',
+			baseUrl: 'https://grpc.testnet.penumbra.zone',
 		})
 		const client = createPromiseClient(ObliviousQueryService, transport)
 


### PR DESCRIPTION
As of Testnet 53 Himalia, we have working HTTPS for both pd's gRPC service and Tendermint's API. Let's default to those values throughout the config, so we're no longer using HTTP-only network calls. Matches changed in [0].

[0] https://github.com/penumbra-zone/wallet/pull/6