### PR TITLE
bech32 test: working example cases

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
 container:
     docker build -t penumbra_dapp .
     docker run -p 9012:9012 -it penumbra_dapp
+
+dev-shell:
+    docker build -t penumbra_dapp .
+    docker run -p 9012:9012 -v $PWD:/usr/src/app -it penumbra_dapp bash

--- a/src/test/bech32.spec.ts
+++ b/src/test/bech32.spec.ts
@@ -1,21 +1,39 @@
 import {fromBase64} from "@cosmjs/encoding";
-import {bech32m} from "bech32";
+import {bech32} from "bech32";
 import {expect, jest, test, describe, it} from '@jest/globals';
 
 
-describe("bech32", () => {
+describe("penumbraAddress", () => {
 
-    const addressByteArray = fromBase64("uO4xMmm5xcE4F1NMZHSCuLerUIZcABueUXSylcnQqYV7uEW8/lFKAClU7mOm4KSwJEDS9F/ToRMWrY4e3WxEIepSdTtxZU9rLni+cp0cvJ0=");
+    // Most of RPC methods relating to addresses return a base64-encoded string.
+    // In order to confirm we can parse an address correctly, we must:
+    //
+    //   1. Convert a base64 message to an array of uint8s, 80 elements long.
+    //   2. Convert the byte arrays to a readable Penumbra string representation.
+    //   3. Confirm that the Penumbra string representation matches our expectations.
+    //
+    const penumbraAddress = "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yav3m37k";
+    const penumbraAddressBase64 = "uO4xMmm5xcE4F1NMZHSCuLerUIZcABueUXSylcnQqYV7uEW8/lFKAClU7mOm4KSwJEDS9F/ToRMWrY4e3WxEIepSdTtxZU9rLni+cp0cvJ0=";
+    const penumbraAddressByteArray = fromBase64(penumbraAddressBase64);
+    const penumbraAddressLimit = 146;
 
+    describe("toBytes", () => {
+        it("works", () => {
+            expect(penumbraAddressByteArray.length).toBe(80);
+            penumbraAddressByteArray.forEach((i) => {
+                expect(i).toBeGreaterThanOrEqual(0);
+                expect(i).toBeLessThanOrEqual(255);
+            });
+        });
+    })
 
     describe("toBech32", () => {
         it("works", () => {
-
-            expect(bech32m.encode(
+            expect(bech32.encode(
                 'penumbrav2t',
-                bech32m.toWords(addressByteArray),
-                156
-            )).toEqual("penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yav3m37k");
+                bech32.toWords(penumbraAddressByteArray),
+                penumbraAddressLimit,
+            )).toEqual(penumbraAddress);
         });
     })
 });

--- a/src/test/bech32.spec.ts
+++ b/src/test/bech32.spec.ts
@@ -1,5 +1,5 @@
 import {fromBase64} from "@cosmjs/encoding";
-import {bech32} from "bech32";
+import {bech32, bech32m} from "bech32";
 import {expect, jest, test, describe, it} from '@jest/globals';
 
 
@@ -16,6 +16,14 @@ describe("penumbraAddress", () => {
     const penumbraAddressBase64 = "uO4xMmm5xcE4F1NMZHSCuLerUIZcABueUXSylcnQqYV7uEW8/lFKAClU7mOm4KSwJEDS9F/ToRMWrY4e3WxEIepSdTtxZU9rLni+cp0cvJ0=";
     const penumbraAddressByteArray = fromBase64(penumbraAddressBase64);
     const penumbraAddressLimit = 146;
+
+    const addresses = [
+        "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yav3m37k",
+        "penumbrav2t13vh0fkf3qkqjacpm59g23ufea9n5us45e4p5h6hty8vg73r2t8g5l3kynad87u0n9eragf3hhkgkhqe5vhngq2cw493k48c9qg9ms4epllcmndd6ly4v4dw2jcnxaxzjqnlvnw",
+        "penumbrav2t1ty7ns3hwcnqelrtmn6f72znf49td8hzxntchjglntl2evx42zl00y3u939zk83l2v2f8zj55gn50k78wxdvnfqk97kv4azlwjyle893zqgg9cqa6rycs9ucq3lf9ae4jk5vtrf",
+        "penumbrav2t1s5p3dlh42p8skam328sl6r9qyj0nc3p75p5rftjyg9rw8wlhc34gruwkwj4pw4yj93muglftpjwh406edc6n07xp3u7dxg54mveqgc5wvac4srs2wzg9zp2eu385gn6g8rsyh2",
+        "penumbrav2t1qj9045mzfavgkfe0st9fthmrrup99xgnnrqn88nkf3pyfekg8gg4t5k2zwgtxa0584cz7j907js3enuh3lz84qjv35hlu36r9n28a82dr2pt5ysx3slqnr0xp6tvlfqvgl55p6"
+    ]
 
     describe("toBytes", () => {
         it("works", () => {
@@ -36,4 +44,25 @@ describe("penumbraAddress", () => {
             )).toEqual(penumbraAddress);
         });
     })
+
+
+    describe("decode and encode", () => {
+        addresses.forEach( address => {
+            it("works " + address, () => {
+                let decoded = bech32.decode(
+                    address,
+                    penumbraAddressLimit);
+
+                expect(decoded.prefix).toEqual("penumbrav2t");
+
+                expect(bech32.encode(
+                    decoded.prefix,
+                    decoded.words,
+                    penumbraAddressLimit,
+                )).toEqual(address);
+            });
+        });
+
+    })
+
 });

--- a/src/test/bech32.spec.ts
+++ b/src/test/bech32.spec.ts
@@ -12,13 +12,13 @@ describe("penumbraAddress", () => {
     //   2. Convert the byte arrays to a readable Penumbra string representation.
     //   3. Confirm that the Penumbra string representation matches our expectations.
     //
-    const penumbraAddress = "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yav3m37k";
+    const penumbraAddress = "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yaedtam5";
     const penumbraAddressBase64 = "uO4xMmm5xcE4F1NMZHSCuLerUIZcABueUXSylcnQqYV7uEW8/lFKAClU7mOm4KSwJEDS9F/ToRMWrY4e3WxEIepSdTtxZU9rLni+cp0cvJ0=";
     const penumbraAddressByteArray = fromBase64(penumbraAddressBase64);
     const penumbraAddressLimit = 146;
 
     const addresses = [
-        "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yav3m37k",
+        "penumbrav2t1hrhrzvnfh8zuzwqh2dxxgayzhzm6k5yxtsqph8j3wjeftjws4xzhhwz9hnl9zjsq992wucaxuzjtqfzq6t69l5apzvt2mrs7m4kygg022f6nkut9fa4ju797w2w3e0yaedtam5",
         "penumbrav2t13vh0fkf3qkqjacpm59g23ufea9n5us45e4p5h6hty8vg73r2t8g5l3kynad87u0n9eragf3hhkgkhqe5vhngq2cw493k48c9qg9ms4epllcmndd6ly4v4dw2jcnxaxzjqnlvnw",
         "penumbrav2t1ty7ns3hwcnqelrtmn6f72znf49td8hzxntchjglntl2evx42zl00y3u939zk83l2v2f8zj55gn50k78wxdvnfqk97kv4azlwjyle893zqgg9cqa6rycs9ucq3lf9ae4jk5vtrf",
         "penumbrav2t1s5p3dlh42p8skam328sl6r9qyj0nc3p75p5rftjyg9rw8wlhc34gruwkwj4pw4yj93muglftpjwh406edc6n07xp3u7dxg54mveqgc5wvac4srs2wzg9zp2eu385gn6g8rsyh2",
@@ -37,9 +37,9 @@ describe("penumbraAddress", () => {
 
     describe("toBech32", () => {
         it("works", () => {
-            expect(bech32.encode(
+            expect(bech32m.encode(
                 'penumbrav2t',
-                bech32.toWords(penumbraAddressByteArray),
+                bech32m.toWords(penumbraAddressByteArray),
                 penumbraAddressLimit,
             )).toEqual(penumbraAddress);
         });
@@ -49,13 +49,13 @@ describe("penumbraAddress", () => {
     describe("decode and encode", () => {
         addresses.forEach( address => {
             it("works " + address, () => {
-                let decoded = bech32.decode(
+                let decoded = bech32m.decode(
                     address,
                     penumbraAddressLimit);
 
                 expect(decoded.prefix).toEqual("penumbrav2t");
 
-                expect(bech32.encode(
+                expect(bech32m.encode(
                     decoded.prefix,
                     decoded.words,
                     penumbraAddressLimit,


### PR DESCRIPTION
Updates the new bech32 test cases with working examples, showing how to convert a base64-encoded Penumbra address to byte slice suitable for bech32 re-encoding back to a string representation of the address. Puzzlingly, the `bech32m` methods don't do what we want, so we use the `bech32` methods instead.