### PR TITLE
Create React components for action views

### DIFF
--- a/src/app/tx/page.tsx
+++ b/src/app/tx/page.tsx
@@ -22,20 +22,11 @@ import { getTransactionType } from '@/lib/transactionType'
 import dynamic from 'next/dynamic'
 import { AddressComponent } from '@/components/penumbra/Address'
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb'
+import { TransactionHashComponent } from '@/components/penumbra/TransactionHash'
 //import ReactJson from '@microlink/react-json-view';
 const DynamicReactJson = dynamic(() => import('@microlink/react-json-view'), {
 	ssr: false // This line is important. It's what prevents server-side rendering.
 })
-
-function truncateHash(hash: string | null, length: number = 6): string {
-	if (hash === null) {
-		return '';
-	}
-	if (hash.length <= 2 * length) {
-		return hash;
-	}
-	return hash.slice(0, length) + '…' + hash.slice(-length);
-}
 
 export default function TransactionDetail() {
 	const auth = useAuth()
@@ -337,21 +328,12 @@ export default function TransactionDetail() {
 									className='self-start'
 								/>
 								<div className='h1 mb-[12px] mt-[24px]'>
-									<p
-										style={{ display: "inline-block" }}
-									>Transaction <span className='monospace'>{truncateHash(params.get('hash'), 8)}</span></p>
-									<p
-										className='cursor-pointer hover:no-underline hover:opacity-75'
-										onClick={copyToClipboard}
-										style={{ display: "inline-block", margin: "0 5px" }}
-									>
-										<CopySvg width='20' height='20' fill='#524B4B' />
-									</p>
-									<p
-										style={{ display: "inline-block" }}
-									>
-										(Height {Number(tx?.txInfo?.height)})
-									</p>
+									<span>Transaction </span>
+									<TransactionHashComponent
+										hash={params.get('hash') as string}
+										short_form={true}
+									/>
+									<span>(Height {Number(tx?.txInfo?.height)})</span>
 								</div>
 								<p className='h2 mb-[12px] mt-[16px]'>Memo</p>
 								<div className='flex flex-col p-[16px] gap-y-[16px] w-[800px] bg-brown rounded-[10px]'>

--- a/src/app/tx/page.tsx
+++ b/src/app/tx/page.tsx
@@ -20,6 +20,8 @@ import { ChevronLeftIcon, CopySvg } from '@/components/Svg'
 import { getTransactionType } from '@/lib/transactionType'
 
 import dynamic from 'next/dynamic'
+import { AddressComponent } from '@/components/penumbra/Address'
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb'
 //import ReactJson from '@microlink/react-json-view';
 const DynamicReactJson = dynamic(() => import('@microlink/react-json-view'), {
 	ssr: false // This line is important. It's what prevents server-side rendering.
@@ -55,6 +57,7 @@ export default function TransactionDetail() {
 	let memoSender = 'Encrypted';
 	//console.log(memoView)
 	//console.log(bodyView)
+	let memoReturnAddress: Address | undefined = undefined;
 	if (memoView?.case == 'visible') {
 		memoText = memoView.value.plaintext!.text;
 		memoSender = bech32m.encode(
@@ -62,6 +65,7 @@ export default function TransactionDetail() {
 			bech32m.toWords(memoView.value.plaintext!.sender!.inner),
 			160
 		);
+		memoReturnAddress = memoView.value.plaintext?.sender
 	}
 
 	let chainId = bodyView?.chainId;
@@ -351,20 +355,6 @@ export default function TransactionDetail() {
 								</div>
 								<p className='h2 mb-[12px] mt-[16px]'>Memo</p>
 								<div className='flex flex-col p-[16px] gap-y-[16px] w-[800px] bg-brown rounded-[10px]'>
-									{
-										memoSender === 'Encrypted' ? (
-											<div className='w-[100%] flex flex-col'>
-												<p className='h3 mb-[8px] capitalize encrypted'>Sender Address</p>
-											</div>
-										) : (
-											<div className='w-[100%] flex flex-col'>
-												<p className='h3 mb-[8px] capitalize'>Sender Address</p>
-												<p className='py-[8px] px-[16px] bg-dark_grey rounded-[15px] text_numbers_s text-light_grey break-words monospace'>
-													{memoSender}
-												</p>
-											</div>
-										)
-									}
 									{memoText === 'Encrypted' ? (
 										<div className='w-[100%] flex flex-col'>
 											<p className='h3 mb-[8px] capitalize encrypted'>Message</p>
@@ -381,6 +371,20 @@ export default function TransactionDetail() {
 											</p>
 										</div>
 									)}
+									{
+										memoSender === 'Encrypted' ? (
+											<div className='w-[100%] flex flex-col'>
+												<p className='h3 mb-[8px] capitalize encrypted'>Return Address</p>
+											</div>
+										) : (
+											<div className='w-[100%] flex flex-col'>
+												<p className='h3 mb-[8px] capitalize'>Return Address</p>
+												<p className='py-[8px] px-[16px] bg-dark_grey rounded-[15px] text_numbers_s text-light_grey break-words monospace'>
+													<AddressComponent address={memoReturnAddress!} />
+												</p>
+											</div>
+										)
+									}
 								</div>
 								<p className='h2 mb-[12px] mt-[16px]'>Actions</p>
 								<div className='flex flex-col p-[16px] gap-y-[16px] w-[800px] bg-brown rounded-[10px]'>

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRightSvg, ChevronLeftIcon } from './Svg'
 import { getTransactionType } from '@/lib/transactionType'
 import Link from 'next/link'
 import { routesPath } from '@/lib/constants'
+import { TransactionHashComponent } from './penumbra/TransactionHash'
 
 export const ActivityList = () => {
 	const { transactions } = useTransactions()
@@ -24,14 +25,13 @@ export const ActivityList = () => {
 										<p className='h3 w-[80px] mb-[8px]'>
 											{getTransactionType(i.txInfo?.view)}
 										</p>
-										<p className='text_body text-green'>Block height :</p>
+										<p className='text_body text-green'>Height</p>
 										<p className='text_body text-green'>
 											{String(i.txInfo?.height)}
 										</p>
 									</div>
-									<p className='text_body ml-[14px]'>Hash: </p>
-									<p className='text_body ml-[14px] break-all'>
-										{uint8ToBase64(i.txInfo?.id?.hash!)}
+									<p className='text_body ml-[14px]'>
+										<TransactionHashComponent short_form={false} hash={uint8ToBase64(i.txInfo?.id?.hash!)} />
 									</p>
 								</div>
 								<Link

--- a/src/components/penumbra/Address.tsx
+++ b/src/components/penumbra/Address.tsx
@@ -40,6 +40,15 @@ export const AddressViewComponent: React.FC<{ addressView: AddressView }> = ({ a
 
     switch (addressView.addressView.case) {
         case 'visible':
+            const view = addressView.addressView.value;
+            const account = view.index?.account || 0;
+            return (
+                <>
+                    <AddressComponent address={address} />
+                    {account === 0 ? (<span>(Self)</span >)
+                        : (<span>(Self Account {account})</span>)}
+                </>
+            )
         case 'opaque':
             return <AddressComponent address={address} />;
     }

--- a/src/components/penumbra/Address.tsx
+++ b/src/components/penumbra/Address.tsx
@@ -8,7 +8,7 @@ import { CopySvg } from '../Svg';
 import { copyToClipboard } from '@/lib/copyToClipboard';
 
 // A Penumbra address in short form with a copy button
-export const AddressComponent: React.FC<{ address: Address }> = ({ address }) => {
+export const AddressComponent: React.FC<{ address: Address, show_full?: boolean }> = ({ address, show_full }) => {
     const prefix = 'penumbrav2t';
     const address_str = bech32m.encode(
         prefix,
@@ -16,11 +16,12 @@ export const AddressComponent: React.FC<{ address: Address }> = ({ address }) =>
         160,
     );
     const address_str_short = address_str.slice(0, prefix.length + 1 + 24) + "…";
+    const display_address = show_full ? address_str : address_str_short;
 
     return (
         <> {
             <div style={{ display: "inline-block" }}>
-                <span className="monospace">{address_str_short}</span>
+                <span className="monospace">{display_address}</span>
                 <span
                     className='cursor-pointer hover:no-underline hover:opacity-75'
                     onClick={() => copyToClipboard(address_str)}

--- a/src/components/penumbra/Address.tsx
+++ b/src/components/penumbra/Address.tsx
@@ -1,0 +1,48 @@
+
+
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb';
+import { bech32m } from 'bech32';
+import React from 'react';
+import toast from 'react-hot-toast';
+import { CopySvg } from '../Svg';
+
+// A Penumbra address in short form with a copy button
+export const AddressComponent: React.FC<{ address: Address }> = ({ address }) => {
+    const prefix = 'penumbrav2t';
+    const address_str = bech32m.encode(
+        prefix,
+        bech32m.toWords(address.inner),
+        160,
+    );
+    const address_str_short = address_str.slice(0, prefix.length + 1 + 24) + "…";
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text)
+        toast.success('Successfully copied', {
+            position: 'top-center',
+            icon: '👏',
+            style: {
+                borderRadius: '15px',
+                background: '#141212',
+                color: '#fff',
+            },
+        })
+    }
+
+    return (
+        <> {
+
+            <div style={{ display: "inline-block" }}>
+                <span className="monospace">{address_str_short}</span>
+                <span
+                    className='cursor-pointer hover:no-underline hover:opacity-75'
+                    onClick={() => copyToClipboard(address_str)}
+                    style={{ display: "inline-block", margin: "0 5px" }}
+                >
+                    <CopySvg width='1em' height='1em' fill='#524B4B' />
+                </span>
+            </div>
+        }
+        </>
+    )
+}

--- a/src/components/penumbra/Address.tsx
+++ b/src/components/penumbra/Address.tsx
@@ -1,6 +1,6 @@
 
 
-import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb';
+import { Address, AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb';
 import { bech32m } from 'bech32';
 import React from 'react';
 import toast from 'react-hot-toast';
@@ -19,7 +19,6 @@ export const AddressComponent: React.FC<{ address: Address }> = ({ address }) =>
 
     return (
         <> {
-
             <div style={{ display: "inline-block" }}>
                 <span className="monospace">{address_str_short}</span>
                 <span
@@ -33,4 +32,15 @@ export const AddressComponent: React.FC<{ address: Address }> = ({ address }) =>
         }
         </>
     )
+}
+
+// A Penumbra address in short form with a copy button and info on the account it represents.
+export const AddressViewComponent: React.FC<{ addressView: AddressView }> = ({ addressView }) => {
+    const address = addressView.addressView.value?.address!;
+
+    switch (addressView.addressView.case) {
+        case 'visible':
+        case 'opaque':
+            return <AddressComponent address={address} />;
+    }
 }

--- a/src/components/penumbra/TransactionHash.tsx
+++ b/src/components/penumbra/TransactionHash.tsx
@@ -7,24 +7,27 @@ import toast from 'react-hot-toast';
 import { CopySvg } from '../Svg';
 import { copyToClipboard } from '@/lib/copyToClipboard';
 
-// A Penumbra address in short form with a copy button
-export const AddressComponent: React.FC<{ address: Address }> = ({ address }) => {
-    const prefix = 'penumbrav2t';
-    const address_str = bech32m.encode(
-        prefix,
-        bech32m.toWords(address.inner),
-        160,
-    );
-    const address_str_short = address_str.slice(0, prefix.length + 1 + 24) + "…";
+function truncateHash(hash: string | null, length: number = 6): string {
+    if (hash === null) {
+        return '';
+    }
+    if (hash.length <= 2 * length) {
+        return hash;
+    }
+    return hash.slice(0, length) + '…' + hash.slice(-length);
+}
+
+// A transaction hash, optionally in short form, with a copy button
+export const TransactionHashComponent: React.FC<{ hash: string, short_form?: boolean }> = ({ hash, short_form }) => {
+    let display_hash = short_form ? truncateHash(hash, 8) : hash;
 
     return (
         <> {
-
             <div style={{ display: "inline-block" }}>
-                <span className="monospace">{address_str_short}</span>
+                <span className="monospace">{display_hash}</span>
                 <span
                     className='cursor-pointer hover:no-underline hover:opacity-75'
-                    onClick={() => copyToClipboard(address_str)}
+                    onClick={() => copyToClipboard(hash)}
                     style={{ display: "inline-block", margin: "0 5px" }}
                 >
                     <CopySvg width='1em' height='1em' fill='#524B4B' />

--- a/src/components/penumbra/view/ActionView.tsx
+++ b/src/components/penumbra/view/ActionView.tsx
@@ -1,0 +1,20 @@
+import { ActionView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb";
+import { SpendViewComponent } from "./SpendView";
+import { OutputViewComponent } from "./OutputView";
+
+
+export const ActionViewComponent: React.FC<{ actionView: ActionView }> = ({ actionView }) => {
+    switch (actionView.actionView.case) {
+        case 'spend':
+            return <SpendViewComponent view={actionView.actionView.value} />;
+        case 'output':
+            return <OutputViewComponent view={actionView.actionView.value} />;
+        // TODO: add a component for each action type (FooViewComponent if view or just FooComponent for actions that are their own views)
+        //case 'swap':
+        //    return <SwapViewComponent view={actionView.actionView.value} />;
+        default:
+            return <div className='w-[100%] flex flex-col'>
+                <p className='h3 mb-[8px] capitalize'>Unknown Action</p>
+            </div>
+    }
+}

--- a/src/components/penumbra/view/OutputView.tsx
+++ b/src/components/penumbra/view/OutputView.tsx
@@ -1,0 +1,59 @@
+import { useBalance } from "@/context/BalanceContextProvider";
+import { getAssetByAssetId } from "@/lib/assets";
+import { uint8ToBase64 } from "@/lib/uint8ToBase64";
+import { OutputView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb"
+import { AddressComponent } from "../Address";
+
+
+export const OutputViewComponent: React.FC<{ view: OutputView }> = ({ view }) => {
+    // TODO: can the asset info be put in the view correctly instead?
+    const { assets } = useBalance()
+    console.log(assets)
+
+    switch (view.outputView.case) {
+        case 'visible': {
+            // view.outputView.value is OutputView_Visible
+            const visibleOutput = view.outputView.value;
+
+            const address = visibleOutput.note?.address?.addressView.value?.address!;
+            const valueView = visibleOutput.note?.value?.valueView;
+
+            // TODO: handle known/unknown denoms
+            // TODO: may need fixes to view protos
+            // TODO: knownDenom only has a denom string, not a denom metadata...
+            const denomMetadata = getAssetByAssetId(
+                assets,
+                // this is only OK for now because the extension currently
+                // doesn't populate any denom info
+                //@ts-ignore
+                uint8ToBase64(valueView?.value?.assetId!.inner as Uint8Array)
+            )?.denomMetadata
+
+            // TODO: human-formatting an amount should be a helper function
+            // TODO: ValueView component?
+            const amount = valueView?.value?.amount;
+            const exponent = denomMetadata?.denomUnits.find(
+                i => i.denom === denomMetadata?.display
+            )?.exponent || 1
+            const humanAmount =
+                (Number(amount?.lo) + 2 ** 64 * Number(amount?.hi)) / (10 ** exponent)
+
+            let humanDenom = denomMetadata?.display /* TODO: || passet1... for unknown denoms */
+
+            return <div className='w-[100%] flex flex-col'>
+                <p className='h3 mb-[8px] capitalize'>Output</p>
+                <p className='py-[8px] px-[16px] bg-dark_grey rounded-[15px] text_numbers_s text-light_grey break-words '>
+                    <span>
+                        {humanAmount} {humanDenom} to
+                    </span>
+                    <AddressComponent address={address} />
+                </p>
+            </div>
+        }
+        default: {
+            return <div className='w-[100%] flex flex-col'>
+                <p className='h3 mb-[8px] capitalize encrypted'>Output</p>
+            </div>
+        }
+    }
+}

--- a/src/components/penumbra/view/OutputView.tsx
+++ b/src/components/penumbra/view/OutputView.tsx
@@ -2,7 +2,7 @@ import { useBalance } from "@/context/BalanceContextProvider";
 import { getAssetByAssetId } from "@/lib/assets";
 import { uint8ToBase64 } from "@/lib/uint8ToBase64";
 import { OutputView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb"
-import { AddressComponent } from "../Address";
+import { AddressComponent, AddressViewComponent } from "../Address";
 
 
 export const OutputViewComponent: React.FC<{ view: OutputView }> = ({ view }) => {
@@ -15,7 +15,7 @@ export const OutputViewComponent: React.FC<{ view: OutputView }> = ({ view }) =>
             // view.outputView.value is OutputView_Visible
             const visibleOutput = view.outputView.value;
 
-            const address = visibleOutput.note?.address?.addressView.value?.address!;
+            const addressView = visibleOutput.note?.address!;
             const valueView = visibleOutput.note?.value?.valueView;
 
             // TODO: handle known/unknown denoms
@@ -46,7 +46,7 @@ export const OutputViewComponent: React.FC<{ view: OutputView }> = ({ view }) =>
                     <span>
                         {humanAmount} {humanDenom} to
                     </span>
-                    <AddressComponent address={address} />
+                    <AddressViewComponent addressView={addressView} />
                 </p>
             </div>
         }

--- a/src/components/penumbra/view/SpendView.tsx
+++ b/src/components/penumbra/view/SpendView.tsx
@@ -2,7 +2,7 @@ import { useBalance } from "@/context/BalanceContextProvider";
 import { getAssetByAssetId } from "@/lib/assets";
 import { uint8ToBase64 } from "@/lib/uint8ToBase64";
 import { SpendView, SpendView_Opaque, SpendView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb"
-import { AddressComponent } from "../Address";
+import { AddressViewComponent } from "../Address";
 
 export const SpendViewComponent: React.FC<{ view: SpendView }> = ({ view }) => {
     // TODO: can the asset info be put in the view correctly instead?
@@ -13,7 +13,7 @@ export const SpendViewComponent: React.FC<{ view: SpendView }> = ({ view }) => {
             // spendView.spendView.value is SpendView_Visible
             const visibleSpend: SpendView_Visible = view.spendView.value;
             const valueView = visibleSpend.note?.value?.valueView;
-            const address = visibleSpend.note?.address?.addressView.value?.address!;
+            const addressView = visibleSpend.note?.address!;
 
             // TODO: handle known/unknown denoms
             // TODO: may need fixes to view protos
@@ -43,7 +43,7 @@ export const SpendViewComponent: React.FC<{ view: SpendView }> = ({ view }) => {
                     <span>
                         {humanAmount} {humanDenom} from
                     </span>
-                    <AddressComponent address={address} />
+                    <AddressViewComponent addressView={addressView} />
                 </p>
             </div>
         }

--- a/src/components/penumbra/view/SpendView.tsx
+++ b/src/components/penumbra/view/SpendView.tsx
@@ -1,0 +1,58 @@
+import { useBalance } from "@/context/BalanceContextProvider";
+import { getAssetByAssetId } from "@/lib/assets";
+import { uint8ToBase64 } from "@/lib/uint8ToBase64";
+import { SpendView, SpendView_Opaque, SpendView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb"
+import { AddressComponent } from "../Address";
+
+export const SpendViewComponent: React.FC<{ view: SpendView }> = ({ view }) => {
+    // TODO: can the asset info be put in the view correctly instead?
+    const { assets } = useBalance()
+
+    switch (view.spendView.case) {
+        case 'visible': {
+            // spendView.spendView.value is SpendView_Visible
+            const visibleSpend: SpendView_Visible = view.spendView.value;
+            const valueView = visibleSpend.note?.value?.valueView;
+            const address = visibleSpend.note?.address?.addressView.value?.address!;
+
+            // TODO: handle known/unknown denoms
+            // TODO: may need fixes to view protos
+            // TODO: knownDenom only has a denom string, not a denom metadata...
+            const denomMetadata = getAssetByAssetId(
+                assets,
+                // this is only OK for now because the extension currently
+                // doesn't populate any denom info
+                //@ts-ignore
+                uint8ToBase64(valueView?.value?.assetId!.inner as Uint8Array)
+            )?.denomMetadata
+
+            // TODO: human-formatting an amount should be a helper function
+            // TODO: ValueView component?
+            const amount = valueView?.value?.amount;
+            const exponent = denomMetadata?.denomUnits.find(
+                i => i.denom === denomMetadata?.display
+            )?.exponent || 1
+            const humanAmount =
+                (Number(amount?.lo) + 2 ** 64 * Number(amount?.hi)) / (10 ** exponent)
+
+            let humanDenom = denomMetadata?.display /* TODO: || passet1... for unknown denoms */
+
+            return <div className='w-[100%] flex flex-col'>
+                <p className='h3 mb-[8px] capitalize'>Spend</p>
+                <p className='py-[8px] px-[16px] bg-dark_grey rounded-[15px] text_numbers_s text-light_grey break-words '>
+                    <span>
+                        {humanAmount} {humanDenom} from
+                    </span>
+                    <AddressComponent address={address} />
+                </p>
+            </div>
+        }
+        default: {
+            // spendView.spendView.value is SpendView_Opaque
+            //const opaqueSpend: SpendView_Opaque = view.spendView.value;
+            return <div className='w-[100%] flex flex-col'>
+                <p className='h3 mb-[8px] capitalize encrypted'>Spend</p>
+            </div>
+        }
+    }
+}

--- a/src/lib/copyToClipboard.ts
+++ b/src/lib/copyToClipboard.ts
@@ -2,7 +2,7 @@ import toast from "react-hot-toast"
 
 export const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text)
-    toast.success('Successfully copied', {
+    toast.success('Copied to clipboard', {
         position: 'top-center',
         icon: '👏',
         style: {

--- a/src/lib/copyToClipboard.ts
+++ b/src/lib/copyToClipboard.ts
@@ -1,0 +1,14 @@
+import toast from "react-hot-toast"
+
+export const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text)
+    toast.success('Successfully copied', {
+        position: 'top-center',
+        icon: '👏',
+        style: {
+            borderRadius: '15px',
+            background: '#141212',
+            color: '#fff',
+        },
+    })
+}


### PR DESCRIPTION
This PR refactors the existing code in the transaction viewer towards code that would eventually render an entire `TransactionView` as a single react component, with subcomponents for each part of the transaction view.  This will enhance reusability and maintenance when trying to support many different action types.