### PR TITLE
Use 'Balance' rather than 'BalanceByAddress' to match proto changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ import {
 	AddressByIndexRequest,
 	AssetsRequest,
 	AssetsResponse,
-	BalanceByAddressRequest,
-	BalanceByAddressResponse,
+	BalancesRequest,
+	BalancesResponse,
 	ChainParametersRequest,
 	ChainParametersResponse,
 	FMDParametersRequest,
@@ -227,11 +227,11 @@ export const extensionTransport = (s: typeof ViewProtocolService) =>
 					yield new AssetsResponse(res)
 				}
 			},
-			async *balanceByAddress(message: BalanceByAddressRequest) {
+			async *balances(message: BalancesRequest) {
 				window.penumbra.on('balance', balance => receiveMessage(balance))
 
 				for await (const res of createMessageStream()) {
-					yield new BalanceByAddressResponse(res)
+					yield new BalancesResponse(res)
 				}
 			},
 			async *notes(message: NotesRequest) {
@@ -285,7 +285,7 @@ const client = createPromiseClient(
   - [ChainParameters](#chain_parameters)
   - [FMDParameters](#fmd_parameters)
   - [AddressByIndex](#address_by_index)
-  - [BalanceByAddress](#balance_by_address)
+  - [Balances](#balances)
   - [TransactionInfoByHash](#tx_by_hash)
   - [TransactionInfo](#tx_info)
   - [TransactionPlanner](#tx_planner)
@@ -395,7 +395,7 @@ View protocol requests optionally include the account group ID, used to identify
 - [ChainParameters](#chain_parameters)
 - [FMDParameters](#fmd_parameters)
 - [AddressByIndex](#address_by_index)
-- [BalanceByAddress](#balance_by_address)
+- [Balances](#balances)
 - [TransactionInfoByHash](#tx_by_hash)
 - [TransactionInfo](#tx_info)
 - [TransactionPlanner](#tx_planner)
@@ -528,22 +528,22 @@ const response = await client.addressByIndex(request)
 
 [**Response**](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1alpha1#penumbra.view.v1alpha1.AddressByIndexResponse)
 
-<a id="balance_by_address"></a>
+<a id="balances"></a>
 
-## BalanceByAddress
+## Balances
 
 Query for balance of a given address
 
 ```js
-const request = new BalanceByAddressRequest({})
-for await (const balance of client.balanceByAddress(request)) {
+const request = new BalancesRequest({})
+for await (const balance of client.balances(request)) {
 	console.log(balance)
 }
 ```
 
-[**Parameters**](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1alpha1#penumbra.view.v1alpha1.BalanceByAddressRequest)
+[**Parameters**](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1alpha1#penumbra.view.v1alpha1.BalancesRequest)
 
-[**Response**](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1alpha1#penumbra.view.v1alpha1.BalanceByAddressResponse)
+[**Response**](https://buf.build/penumbra-zone/penumbra/docs/main:penumbra.view.v1alpha1#penumbra.view.v1alpha1.BalancesResponse)
 
 <a id="tx_by_hash"></a>
 
@@ -552,7 +552,7 @@ for await (const balance of client.balanceByAddress(request)) {
 Query for a given transaction by its hash.
 
 ```js
-const request = new BalanceByAddressRequest({})
+const request = new BalancesRequest({})
 const response = await client.transactionInfoByHash(request)
 ```
 

--- a/src/context/BalanceContextProvider.tsx
+++ b/src/context/BalanceContextProvider.tsx
@@ -2,8 +2,8 @@
 import {
 	AssetsRequest,
 	AssetsResponse,
-	BalanceByAddressRequest,
-	BalanceByAddressResponse,
+	BalancesRequest,
+	BalancesResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb'
 import { createContext, useContext, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { createPromiseClient } from '@bufbuild/connect'
@@ -40,7 +40,7 @@ type Props = {
 export const BalanceContextProvider = (props: Props) => {
 	const auth = useAuth()
 	const [balance, setBalance] = useState<
-		Record<string, BalanceByAddressResponse>
+		Record<string, BalancesResponse>
 	>({})
 	const [assets, setAssets] = useState<AssetsResponse[]>([])
 
@@ -101,9 +101,9 @@ export const BalanceContextProvider = (props: Props) => {
 				extensionTransport(ViewProtocolService)
 			)
 
-			const request = new BalanceByAddressRequest({})
+			const request = new BalancesRequest({})
 
-			for await (const balance of client.balanceByAddress(request)) {
+			for await (const balance of client.balances(request)) {
 				const asset = uint8ToBase64(balance.asset?.inner!)
 
 				setBalance(state => ({

--- a/src/lib/extensionTransport.ts
+++ b/src/lib/extensionTransport.ts
@@ -4,8 +4,8 @@ import {
 	AddressByIndexRequest,
 	AssetsRequest,
 	AssetsResponse,
-	BalanceByAddressRequest,
-	BalanceByAddressResponse,
+	BalancesRequest,
+	BalancesResponse,
 	ChainParametersRequest,
 	ChainParametersResponse,
 	FMDParametersRequest,
@@ -26,7 +26,7 @@ import {
 
 export const extensionTransport = (s: typeof ViewProtocolService) =>
 	createRouterTransport(({ service }) => {
-		let receiveMessage: (value: unknown) => void = function () {}
+		let receiveMessage: (value: unknown) => void = function () { }
 		function waitForNextMessage() {
 			return new Promise(resolve => {
 				receiveMessage = resolve
@@ -82,11 +82,11 @@ export const extensionTransport = (s: typeof ViewProtocolService) =>
 					yield new AssetsResponse(res as any)
 				}
 			},
-			async *balanceByAddress(message: BalanceByAddressRequest) {
+			async *balances(message: BalancesRequest) {
 				window.penumbra.on('balance', balance => receiveMessage(balance))
 
 				for await (const res of createMessageStream()) {
-					yield new BalanceByAddressResponse(res as any)
+					yield new BalancesResponse(res as any)
 				}
 			},
 			async *notes(message: NotesRequest) {


### PR DESCRIPTION
This updates the TypeScript code to be in line with the changes introduced in penumbra-zone/penumbra#2799 to fix compilation errors.

Corresponding wallet PR: https://github.com/penumbra-zone/wallet/pull/15